### PR TITLE
Refactored websockets to merge in partial states not the whole state

### DIFF
--- a/client/src/js/config.js
+++ b/client/src/js/config.js
@@ -1,5 +1,5 @@
 export const config = {
-    //These use secure version of the url on heroku (https,wss)
-    apiUrl:'https://jitsi-games.onrender.com/',
-    wsUrl:'wss://jitsi-games.onrender.com//',
+    // These use the local version of the URL (http, ws)
+    apiUrl: 'http://localhost:3000/', 
+    wsUrl: 'ws://localhost:3000/',    
 }

--- a/client/src/js/games/Game.js
+++ b/client/src/js/games/Game.js
@@ -6,7 +6,7 @@ export default class Game {
 
         this._dataClient.onGameStateUpdate = (newGameState) => {
             console.log('Received new game state:', newGameState);
-            this.gameState = newGameState;
+            this.mergePartialState(newGameState); // Merge the partial game state update
             this.updateUI();
         };
 
@@ -22,5 +22,24 @@ export default class Game {
         this.gameState = this.initializeGameState();
         this.updateUI();
         this.saveGameState();
+    }
+
+    mergePartialState(partialState) {
+        // Iterate over the keys in the partial state and merge them into the existing game state
+        console.log(partialState,this.gameState)
+        Object.keys(partialState).forEach((key) => {
+            if(Array.isArray(partialState[key])){
+                this.gameState[key] = partialState[key];
+            }
+            else if (typeof partialState[key] === 'object' && this.gameState[key]) {
+                // For objects (like paddles, ball), perform a shallow merge
+                this.gameState[key] = { ...this.gameState[key], ...partialState[key] };
+            } else {
+                // For primitive values (like scores), simply overwrite them
+                this.gameState[key] = partialState[key];
+            }
+        });
+        console.log(partialState,this.gameState)
+
     }
 }

--- a/client/src/js/games/TicTacToe.js
+++ b/client/src/js/games/TicTacToe.js
@@ -22,7 +22,9 @@ export default class TicTacToe extends Game {
         const gridCells = document.querySelectorAll('.cell');
         gridCells.forEach(cell => {
             const cellIndex = parseInt(cell.getAttribute('data-cell-index'));
-            cell.innerHTML = this.gameState.game[cellIndex];
+            if (cell.innerHTML !== this.gameState.game[cellIndex]) {
+                cell.innerHTML = this.gameState.game[cellIndex]; // Update only changed cells
+            }
         });
     }
 
@@ -38,7 +40,7 @@ export default class TicTacToe extends Game {
         this.handleResult();
         this.handlePlayerChange();
         this.updateGrid();
-        this.saveGameState();
+        this.saveGameState(); // Call inherited saveGameState to send full game state
     }
 
     handlePlayerChange() {
@@ -67,7 +69,7 @@ export default class TicTacToe extends Game {
         });
 
         if (roundWon) {
-            setTimeout(() => alert(`${this.gameState.currentPlayer} has won!`), 10);
+            alert(`${this.gameState.currentPlayer} has won!`);
             return;
         }
 
@@ -103,7 +105,7 @@ export default class TicTacToe extends Game {
             this.handleCellClick(event);
         }));
         document.querySelector('.game--restart').addEventListener('click', event => {
-            this.handleRestartGame(event);
+            this.handleRestartGame(event); // Call the inherited handleRestartGame method
         });
     }
 }


### PR DESCRIPTION

### Description

This PR changes how the state is updated between the WebSocket clients. I noticed that updating the whole state object every time something happens in a game is not very efficient.


### Type of Change

- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update

### How Has This Been Tested?

- **Manual Testing:**
    
    - Tested that tictactoe ran just as it did previously 

    

### Checklist

- [x]  I have performed a self-review of my code.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [ ]  I have made corresponding changes to the documentation.
- [ ]  I have added tests that prove my fix is effective or that my feature works.
- [x]  New and existing unit tests pass locally with my changes.