### PR TITLE
Now mutes video between both clients

### DIFF
--- a/client/src/js/DataClient.js
+++ b/client/src/js/DataClient.js
@@ -182,7 +182,14 @@ export default class DataClient {
             const localVideo = document.getElementById("localVideo");
             this.localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
             localVideo.srcObject = this.localStream;
-
+            let videoTrack = this.localStream.getVideoTracks()[0];
+            localVideo.addEventListener('pause', () => {
+                videoTrack.enabled = false;
+              });
+              
+              localVideo.addEventListener('play', () => {
+                videoTrack.enabled = true;
+              });
             this.setupPeerConnection();
         } catch (error) {
             console.error('Error accessing media devices:', error);


### PR DESCRIPTION

### Description

This PR introduces a fix to the muting functionality where before the call would only mute on the originating side now it mutes/stops the call between both clients. This is done my stoping and starting the signal so you'll see a black screen on remote clients that are paused.


### Screenshots


### Type of Change

- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update

### How Has This Been Tested?

- **Manual Testing:**
    
    - Tested normal game functionality with both games 
    - Tested that you can still mute your video when there is only one person in the room 
    - Tested that the call gets muted with both people are in the room
    - Tested that if a person is muted already when a person enters the room they remote remains muted and no erroneous behavior occurs


### Checklist

- [x]  I have performed a self-review of my code.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [ ]  I have made corresponding changes to the documentation.
- [ ]  I have added tests that prove my fix is effective or that my feature works.
- [x]  New and existing unit tests pass locally with my changes.